### PR TITLE
   Fixed two log issues.

### DIFF
--- a/autowisp/browser_interface/processing/log_views.py
+++ b/autowisp/browser_interface/processing/log_views.py
@@ -13,6 +13,7 @@ from autowisp.database.image_processing import ImageProcessingManager
 # pylint: disable=no-name-in-module
 from autowisp.database.data_model import (
     ImageProcessingProgress,
+    LightCurveProcessingProgress,
     Step,
     ImageType,
     ProcessingSequence,
@@ -21,6 +22,14 @@ from autowisp.database.data_model import (
 # pylint: enable=no-name-in-module
 
 datetime_fmt = "%Y%m%d %H:%M:%S"
+
+
+def _get_progress_type(request):
+    """Return the requested progress model and its URL identifier."""
+
+    if request.GET.get("processing_type") == "lightcurve":
+        return LightCurveProcessingProgress, "lightcurve"
+    return ImageProcessingProgress, "image"
 
 
 def review(request, selected_processing_id, min_log_level="WARNING"):
@@ -35,20 +44,37 @@ def review(request, selected_processing_id, min_log_level="WARNING"):
             displayed.
     """
 
+    progress_class, processing_type = _get_progress_type(request)
     context = {
         "selected_processing_id": selected_processing_id,
         "min_log_level": min_log_level,
+        "processing_type": processing_type,
     }
     with start_db_session() as db_session:
         selected_progress = db_session.scalar(
-            select(ImageProcessingProgress).where(
-                ImageProcessingProgress.id == selected_processing_id,
+            select(progress_class).where(
+                progress_class.id == selected_processing_id,
             )
+        )
+        target_column = (
+            LightCurveProcessingProgress.single_photref_id
+            if progress_class is LightCurveProcessingProgress
+            else ImageProcessingProgress.image_type_id
+        )
+        target_id = getattr(selected_progress, target_column.key)
+        image_type_id = (
+            db_session.scalar(
+                select(ProcessingSequence.image_type_id).where(
+                    ProcessingSequence.step_id == selected_progress.step_id
+                )
+            )
+            if progress_class is LightCurveProcessingProgress
+            else target_id
         )
         selected_progress = (
             selected_progress.id,
             selected_progress.step_id,
-            selected_progress.image_type_id,
+            image_type_id,
             selected_progress.started.strftime(datetime_fmt),
             (
                 "-"
@@ -65,20 +91,17 @@ def review(request, selected_processing_id, min_log_level="WARNING"):
             )
             for record in db_session.execute(
                 select(
-                    ImageProcessingProgress.id,
-                    ImageProcessingProgress.started,
-                    ImageProcessingProgress.finished,
+                    progress_class.id,
+                    progress_class.started,
+                    progress_class.finished,
                 ).where(
-                    (ImageProcessingProgress.step_id == selected_progress[1]),
-                    (
-                        ImageProcessingProgress.image_type_id
-                        == selected_progress[2]
-                    ),
+                    progress_class.step_id == selected_progress[1],
+                    target_column == target_id,
                 )
             ).all()
         ]
         context["selected_info"] = selected_progress
-        context["pipeline_steps"] = db_session.execute(
+        image_steps = db_session.execute(
             select(
                 Step.id,
                 func.replace(Step.name, "_", " "),
@@ -90,30 +113,59 @@ def review(request, selected_processing_id, min_log_level="WARNING"):
                 Step.name,
             )
         ).all()
-        context["image_types"] = db_session.execute(
+        lightcurve_steps = db_session.execute(
             select(
-                ProcessingSequence.image_type_id,
-                ImageType.name,
-                ImageProcessingProgress.id,
+                Step.id,
+                func.replace(Step.name, "_", " "),
+                func.max(LightCurveProcessingProgress.id),
             )
-            .select_from(ProcessingSequence)
-            .join(ImageType)
-            .join(
-                ImageProcessingProgress,
-                and_(
-                    (
-                        ImageProcessingProgress.step_id
-                        == ProcessingSequence.step_id
-                    ),
-                    (
-                        ImageProcessingProgress.image_type_id
-                        == ProcessingSequence.image_type_id
-                    ),
-                ),
-            )
-            .where(ProcessingSequence.step_id == selected_progress[1])
-            .group_by(ProcessingSequence.image_type_id, ImageType.name)
+            .join(LightCurveProcessingProgress)
+            .group_by(Step.id, Step.name)
         ).all()
+        context["pipeline_steps"] = sorted(
+            [(*step, "image") for step in image_steps]
+            + [(*step, "lightcurve") for step in lightcurve_steps]
+        )
+
+        if progress_class is LightCurveProcessingProgress:
+            image_type = db_session.execute(
+                select(ImageType.id, ImageType.name)
+                .select_from(ProcessingSequence)
+                .join(ImageType)
+                .where(ProcessingSequence.step_id == selected_progress[1])
+            ).one()
+            context["image_types"] = [
+                (*image_type, selected_processing_id, processing_type)
+            ]
+        else:
+            context["image_types"] = [
+                (*image_type, processing_type)
+                for image_type in db_session.execute(
+                    select(
+                        ProcessingSequence.image_type_id,
+                        ImageType.name,
+                        ImageProcessingProgress.id,
+                    )
+                    .select_from(ProcessingSequence)
+                    .join(ImageType)
+                    .join(
+                        ImageProcessingProgress,
+                        and_(
+                            ImageProcessingProgress.step_id
+                            == ProcessingSequence.step_id,
+                            ImageProcessingProgress.image_type_id
+                            == ProcessingSequence.image_type_id,
+                        ),
+                    )
+                    .where(
+                        ProcessingSequence.step_id == selected_progress[1]
+                    )
+                    .group_by(
+                        ProcessingSequence.image_type_id,
+                        ImageType.name,
+                    )
+                ).all()
+            ]
 
     return render(request, "processing/review.html", context)
 
@@ -123,16 +175,24 @@ def review_single(
 ):
     """A view that shows only one type of output from a processing step."""
 
+    progress_class, processing_type = _get_progress_type(request)
     context = {
         "selected_processing_id": selected_processing_id,
         "what": what,
         "min_log_level": min_log_level,
         "selected_subp": sub_process,
+        "processing_type": processing_type,
     }
 
-    log_output_fnames = ImageProcessingManager(
-        pipeline_run_id=None
-    ).find_processing_outputs(selected_processing_id)
+    with start_db_session() as db_session:
+        processing_progress = db_session.scalar(
+            select(progress_class).where(
+                progress_class.id == selected_processing_id
+            )
+        )
+        log_output_fnames = ImageProcessingManager(
+            pipeline_run_id=None
+        ).find_processing_outputs(processing_progress, db_session)
     context["sub_processes"] = range(1, len(log_output_fnames[1][0]) + 1)
     assert len(log_output_fnames[1][0]) == len(log_output_fnames[1][1])
 

--- a/autowisp/browser_interface/processing/progress_view.py
+++ b/autowisp/browser_interface/processing/progress_view.py
@@ -11,6 +11,7 @@ from django.shortcuts import render
 
 from autowisp.database.interface import start_db_session
 from autowisp.database.user_interface import (
+    LIGHT_CURVE_STEPS,
     get_processing_sequence,
     get_progress,
     list_channels,
@@ -22,7 +23,11 @@ from autowisp.error_render import (
 
 # False positive
 # pylint: disable=no-name-in-module
-from autowisp.database.data_model import ImageProcessingProgress, PipelineRun
+from autowisp.database.data_model import (
+    ImageProcessingProgress,
+    LightCurveProcessingProgress,
+    PipelineRun,
+)
 
 # pylint: enable=no-name-in-module
 
@@ -87,22 +92,33 @@ def progress(request, await_start=-1):  # pylint: disable=too-many-locals
                 destination[2][channel_index[channel]][3].append(
                     (status, (count or 0))
                 )
+            progress_class = (
+                LightCurveProcessingProgress
+                if step.name in LIGHT_CURVE_STEPS
+                else ImageProcessingProgress
+            )
+            run_query = select(
+                progress_class.id,
+                progress_class.started,
+                progress_class.finished,
+            ).where(progress_class.step_id == step.id)
+            if progress_class is ImageProcessingProgress:
+                run_query = run_query.where(
+                    ImageProcessingProgress.image_type_id == imtype.id
+                )
+
             destination[3] = [
                 (
                     record[0],
                     record[1].strftime(datetime_fmt) if record[1] else "-",
                     record[2].strftime(datetime_fmt) if record[2] else "-",
+                    (
+                        "lightcurve"
+                        if progress_class is LightCurveProcessingProgress
+                        else "image"
+                    ),
                 )
-                for record in db_session.execute(
-                    select(
-                        ImageProcessingProgress.id,
-                        ImageProcessingProgress.started,
-                        ImageProcessingProgress.finished,
-                    ).where(
-                        ImageProcessingProgress.step_id == step.id,
-                        ImageProcessingProgress.image_type_id == imtype.id,
-                    )
-                ).all()
+                for record in db_session.execute(run_query).all()
             ]
 
         for check_running in db_session.scalars(

--- a/autowisp/browser_interface/processing/static/processing/css/logs.css
+++ b/autowisp/browser_interface/processing/static/processing/css/logs.css
@@ -41,3 +41,42 @@
 .CRITICAL-bg {
     background-color: #e10;
 }
+
+.processing-step-scroll {
+    display: inline-flex;
+    align-self: flex-start;
+    flex: 1 1 auto;
+    height: 2.15rem;
+    min-width: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: thin;
+    white-space: nowrap;
+}
+
+.processing-step-scroll::-webkit-scrollbar {
+    height: 0.45rem;
+}
+
+.processing-step-scroll a {
+    display: inline-flex;
+    flex: 0 0 auto;
+    margin-right: 0.25rem;
+    text-decoration: none;
+}
+
+.processing-step-scroll a:last-child {
+    margin-right: 0;
+}
+
+.processing-step-button {
+    min-width: max-content;
+    width: auto;
+}
+
+.processing-started-title {
+    flex: 0 0 auto;
+    max-width: 40%;
+    min-width: 12rem;
+    width: auto;
+}

--- a/autowisp/browser_interface/processing/static/processing/js/meson.build
+++ b/autowisp/browser_interface/processing/static/processing/js/meson.build
@@ -1,5 +1,6 @@
 src = [
   'review_output.js',
+  'review_steps.js',
   'select.photref.js',
   'tune.starfind.js',
   'progress.js',

--- a/autowisp/browser_interface/processing/static/processing/js/review_steps.js
+++ b/autowisp/browser_interface/processing/static/processing/js/review_steps.js
@@ -1,0 +1,17 @@
+(function() {
+    const stepScroll = document.getElementById("processing-step-scroll");
+
+    if (!stepScroll) {
+        return;
+    }
+
+    stepScroll.scrollLeft = 0;
+    stepScroll.addEventListener("wheel", function(event) {
+        if (stepScroll.scrollWidth <= stepScroll.clientWidth) {
+            return;
+        }
+
+        stepScroll.scrollLeft += event.deltaY || event.deltaX;
+        event.preventDefault();
+    }, {passive: false});
+})();

--- a/autowisp/browser_interface/processing/templates/processing/progress.html
+++ b/autowisp/browser_interface/processing/templates/processing/progress.html
@@ -293,8 +293,9 @@ Processing Progress
                 Logs
             </div>
             <div class="dropdown-content">
-                {% for run_id, started, finished in runs %}
-                <a href="{% url 'processing:review' run_id 'INFO' %}"
+                {% for run_id, started, finished, processing_type in runs %}
+                {% url 'processing:review' run_id 'INFO' as review_url %}
+                <a href="{{ review_url }}{% if processing_type == 'lightcurve' %}?processing_type=lightcurve{% endif %}"
                    class="dropdown-content">
                     Started {{started}}
                 </a>

--- a/autowisp/browser_interface/processing/templates/processing/review.html
+++ b/autowisp/browser_interface/processing/templates/processing/review.html
@@ -5,6 +5,8 @@
         <meta charset="utf-8">
         <title>Review Processing</title>
         <link rel="stylesheet" href="{% static 'css/lcars.css' %}">
+        <link rel="stylesheet"
+              href="{% static 'processing/css/logs.css' %}">
         <style>
             html, body, container {
                 margin: 0px;
@@ -27,11 +29,15 @@
                 <!-- ELBOW -->
                 <div class="lcars-elbow left-bottom lcars-golden-tanoi-bg"></div>
                 <div class="lcars-bar horizontal spacer"></div>
+                <div class="processing-step-scroll"
+                     id="processing-step-scroll">
                 {% for step in pipeline_steps %}
-                <a href="{% url 'processing:review' selected_processing_id=step.2 min_log_level='warning' %}">
+                {% url 'processing:review' selected_processing_id=step.2 min_log_level='warning' as step_url %}
+                <a href="{{ step_url }}{% if step.3 == 'lightcurve' %}?processing_type=lightcurve{% endif %}">
                     <div class="lcars-bar
                                 button
                                 horizontal
+                                processing-step-button
                                 {% if step.0 == selected_info.1 %}
                                 lcars-neon-carrot-bg
                                 {% else %}
@@ -44,7 +50,8 @@
                     </div>
                 </a>
                 {% endfor %}
-                <div class="lcars-bar horizontal">
+                </div>
+                <div class="lcars-bar horizontal processing-started-title">
                     <div class="lcars-title right">
                         Processing started {{selected_info.3}}
                     </div>
@@ -84,8 +91,9 @@
                     </div>
                 </a>
                 {% for processing in reviewable %}
+                {% url 'processing:review' selected_processing_id=processing.0 min_log_level=min_log_level as processing_url %}
                 <a class="lcars-u-1-1"
-                   href="{% url 'processing:review' selected_processing_id=processing.0 min_log_level=min_log_level %}">
+                   href="{{ processing_url }}{% if processing_type == 'lightcurve' %}?processing_type=lightcurve{% endif %}">
                     <div class="lcars-element 
                                 button 
                                 {% if processing.0 == selected_info.0 %}
@@ -115,7 +123,7 @@
                 {% endif %}
                 <a class="lcars-bar horizontal bottom" 
                    style="width: auto"
-                   href="{{change_imtype_url}}">
+                   href="{{change_imtype_url}}{% if imtype.3 == 'lightcurve' %}?processing_type=lightcurve{% endif %}">
                     <div class="lcars-bar
                                 horizontal
                                 bottom
@@ -141,15 +149,18 @@
             </div>
 
             <div id="container"> 
-                <iframe src="{% url 'processing:review' what='log' selected_processing_id=selected_processing_id min_log_level=min_log_level %}" 
+                {% url 'processing:review' what='log' selected_processing_id=selected_processing_id min_log_level=min_log_level as log_url %}
+                <iframe src="{{ log_url }}{% if processing_type == 'lightcurve' %}?processing_type=lightcurve{% endif %}"
                         style="height: 50%;"
                         title="Logs for precessing ID {{selected_processing_id}}"> 
                 </iframe>
-                <iframe src="{% url 'processing:review' what='out' min_log_level='critical' selected_processing_id=selected_processing_id %}" 
+                {% url 'processing:review' what='out' min_log_level='critical' selected_processing_id=selected_processing_id as output_url %}
+                <iframe src="{{ output_url }}{% if processing_type == 'lightcurve' %}?processing_type=lightcurve{% endif %}"
                         style="height: 50%;"
                         title="Standard output and error for precessing ID {{selected_processing_id}}"> 
                 </iframe>
             </div>
+            <script src="{% static 'processing/js/review_steps.js' %}"></script>
     </body>
 </html>
 

--- a/autowisp/browser_interface/processing/templates/processing/review_single.html
+++ b/autowisp/browser_interface/processing/templates/processing/review_single.html
@@ -23,7 +23,8 @@
                     <div class="lcars-bar horizontal spacer"></div>
                     {% with 'DEBUG INFO WARNING ERROR CRITICAL' as log_levels %}
                         {% for level in log_levels.split %}
-                        <a href="{% url 'processing:review' what=what selected_processing_id=selected_processing_id min_log_level=level sub_process=selected_subp %}">
+                        {% url 'processing:review' what=what selected_processing_id=selected_processing_id min_log_level=level sub_process=selected_subp as level_url %}
+                        <a href="{{ level_url }}{% if processing_type == 'lightcurve' %}?processing_type=lightcurve{% endif %}">
                             <div class="lcars-bar
                                         button
                                         horizontal
@@ -47,7 +48,8 @@
                  class="lcars-column" 
                  style="text-transform: uppercase">
                 <div class="lcars-bar spacer"></div>
-                <a href="{% url 'processing:review' what=what selected_processing_id=selected_processing_id min_log_level=min_log_level %}">
+                {% url 'processing:review' what=what selected_processing_id=selected_processing_id min_log_level=min_log_level as main_url %}
+                <a href="{{ main_url }}{% if processing_type == 'lightcurve' %}?processing_type=lightcurve{% endif %}">
                     <div class="lcars-bar 
                                 button 
                                 lcars-u-1-1
@@ -60,7 +62,8 @@
                     </div>
                 </a>
                 {% for subp in sub_processes %}
-                <a href="{% url 'processing:review' what=what selected_processing_id=selected_processing_id min_log_level=min_log_level sub_process=subp %}"
+                {% url 'processing:review' what=what selected_processing_id=selected_processing_id min_log_level=min_log_level sub_process=subp as subp_url %}
+                <a href="{{ subp_url }}{% if processing_type == 'lightcurve' %}?processing_type=lightcurve{% endif %}"
                    class="subp-select"
                    id="Sub{{forloop.counter0}}">
                     <div class="lcars-bar 

--- a/autowisp/database/image_processing.py
+++ b/autowisp/database/image_processing.py
@@ -29,9 +29,11 @@ from autowisp.astrometry import Transformation
 from autowisp.database.data_model import (
     StepDependencies,
     ImageProcessingProgress,
+    LightCurveProcessingProgress,
     ProcessedImages,
     Step,
     Image,
+    ImageType,
     ImageDiagnostics,
     PhotometryDiagnostics,
     DiagnosticType,
@@ -42,6 +44,7 @@ from autowisp.database.data_model import (
     Condition,
     ConditionExpression,
     ImageMasterSelection,
+    ProcessingSequence,
 )
 from autowisp.database.data_model.provenance import (
     Camera,
@@ -1047,8 +1050,8 @@ class ImageProcessingManager(ProcessingManager):
                         header = dr_file.get_frame_header()
                     image_id = db_session.scalar(
                         select(Image.id).where(  # pylint: disable=no-member
-                            Image.raw_fname.like(  # pylint: disable=no-member
-                                f"%/{header['RAWFNAME']}.%"
+                            Image.raw_fname.contains(  # pylint: disable=no-member
+                                f"{header['RAWFNAME']}."
                             )
                         )
                     )
@@ -1705,7 +1708,10 @@ class ImageProcessingManager(ProcessingManager):
                     processing_progress, db_session
                 )
 
-        if not isinstance(processing_progress, ImageProcessingProgress):
+        if not isinstance(
+            processing_progress,
+            (ImageProcessingProgress, LightCurveProcessingProgress),
+        ):
             return self.find_processing_outputs(
                 db_session.scalar(
                     select(ImageProcessingProgress).filter_by(
@@ -1715,12 +1721,25 @@ class ImageProcessingManager(ProcessingManager):
                 db_session,
             )
 
+        if isinstance(processing_progress, ImageProcessingProgress):
+            image_type = processing_progress.image_type.name
+        else:
+            image_type = db_session.scalar(
+                select(ImageType.name)
+                .select_from(ProcessingSequence)
+                .join(ImageType)
+                .where(
+                    ProcessingSequence.step_id == processing_progress.step_id
+                )
+                .limit(1)
+            )
+
         main_fnames = get_log_outerr_filenames(
             existing_pid=processing_progress.run.process_id,
             task="*",
             parent_pid="",
             processing_step=processing_progress.step.name,
-            image_type=processing_progress.image_type.name,
+            image_type=image_type,
             **self._processing_config,
         )
         logging.info("Main fnames: %s", repr(main_fnames))
@@ -1733,7 +1752,7 @@ class ImageProcessingManager(ProcessingManager):
                 task="*",
                 parent_pid=processing_progress.run.process_id,
                 processing_step=processing_progress.step.name,
-                image_type=processing_progress.image_type.name,
+                image_type=image_type,
                 **self._processing_config,
             ),
         )

--- a/autowisp/database/photref_selection.py
+++ b/autowisp/database/photref_selection.py
@@ -236,10 +236,10 @@ def bind_images_to_photref(dr_fname, batch):
 
         pf_image_id = db_session.scalar(
             select(Image.id).where(  # pylint: disable=no-member
-                Image.raw_fname.like(  # pylint: disable=no-member
-                    f"%/{pf_rawfname}.%"
+                Image.raw_fname.contains(  # pylint: disable=no-member
+                    f"{pf_rawfname}."
                 )
-            )
+            ) 
         )
         if pf_image_id is None:
             return

--- a/autowisp/database/user_interface.py
+++ b/autowisp/database/user_interface.py
@@ -343,15 +343,20 @@ def get_progress_lightcurves(
     )
 
 
-def get_progress(step, *args, **kwargs):
-    """Return info about completed work ona given step."""
-
-    if step.name in [
+LIGHT_CURVE_STEPS = frozenset(
+    {
         "epd",
         "tfa",
         "generate_epd_statistics",
         "generate_tfa_statistics",
-    ]:
+    }
+)
+
+
+def get_progress(step, *args, **kwargs):
+    """Return info about completed work ona given step."""
+
+    if step.name in LIGHT_CURVE_STEPS:
         return get_progress_lightcurves(step.id, *args, **kwargs)
 
     return get_progress_images(step.id, *args, **kwargs)


### PR DESCRIPTION
Added horizontal scrolling to the processed-steps bar on the Logs page so all steps remain accessible.
Also fixed the missing Logs buttons for EPD, EPD statistics, TFA, and TFA statistics. These steps store their run information in LightCurveProcessingProgress, while the BUI only checked ImageProcessingProgress. The BUI now uses the correct progress table and preserves the run type while navigating the Logs page, allowing the existing log files to open correctly.