### PR TITLE
Ci astrometry

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -61,6 +61,20 @@ jobs:
           # matrix.extra_pip adds per-cell constraints (Intel mac pins llvmlite).
           python -m pip install "numpy${{ matrix.numpy == '1' && '<2' || '>=2' }}" ${{ matrix.extra_pip }} .
           python -c "from importlib.metadata import version; print('numpy', version('numpy'), '| astrowisp', version('astrowisp'))"
+      # Solve astrometry locally on Linux/macOS: just install solve-field. The
+      # test harness points solve_astrometry at the astrometry.net indices bundled
+      # in the test data (via AUTOWISP_ANET_INDICES). Windows has no practical
+      # solve-field, so local_solver_available() makes it fall back to the web
+      # solver -- and as the only Windows cell it is the one live web check.
+      - name: Install solve-field (local plate solving)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          case "$RUNNER_OS" in
+            Linux) sudo apt-get update -qq && sudo apt-get install -y -qq astrometry.net ;;
+            macOS) brew install astrometry-net ;;
+            *) echo "No solve-field install for $RUNNER_OS"; exit 1 ;;
+          esac
       - name: Run tests
         shell: bash
         run: |

--- a/autowisp/astrometry/astrometry.py
+++ b/autowisp/astrometry/astrometry.py
@@ -297,6 +297,31 @@ def create_config_file(config_fname, fov_range, anet_indices):
         _logger.debug("Astrometry.net engine config:\n%s", config_file.read())
 
 
+def _ansvr_bash():
+    """Return the ANSVR cygwin ``bash`` path on Windows if installed, else None.
+
+    ANSVR (https://adgsoftware.com/ansvr/) is how ``solve-field`` is provided on
+    Windows; its ``solve-field`` is a cygwin binary invoked through this bash,
+    so it never appears on the Windows PATH.
+    """
+
+    if os.name != "nt":
+        return None
+    bash_exe = os.environ.get(
+        "ANSVR_BASH",
+        os.path.expandvars(r"%LOCALAPPDATA%\cygwin_ansvr\bin\bash.exe"),
+    )
+    return bash_exe if os.path.exists(bash_exe) else None
+
+
+def local_solver_available():
+    """Whether a local ``solve-field`` can be invoked (native or via ANSVR)."""
+
+    if os.name == "nt":
+        return _ansvr_bash() is not None
+    return shutil.which("solve-field") is not None
+
+
 def get_initial_corr_local(
     header, xy_extracted, tweak_order_range, fov_range, anet_indices
 ):
@@ -314,14 +339,8 @@ def get_initial_corr_local(
         config_fname,
     ):
         xy_extracted = create_sources_file(xy_extracted, sources_fname)
-        use_ansvr = False
-        bash_exe = None
-        if os.name == "nt":
-            bash_exe = os.environ.get(
-                "ANSVR_BASH",
-                os.path.expandvars(r"%LOCALAPPDATA%\cygwin_ansvr\bin\bash.exe"),
-            )
-            use_ansvr = os.path.exists(bash_exe)
+        bash_exe = _ansvr_bash()
+        use_ansvr = bash_exe is not None
 
         create_config_file(config_fname, fov_range, anet_indices)
 
@@ -521,6 +540,7 @@ def get_initial_corr(
         "anet_indices" in config
         and os.path.exists(config["anet_indices"][0])
         and os.path.exists(config["anet_indices"][1])
+        and local_solver_available()
     ):
         return get_initial_corr_local(*initial_corr_arg, config["anet_indices"])
 

--- a/autowisp/processing_steps/solve_astrometry.py
+++ b/autowisp/processing_steps/solve_astrometry.py
@@ -72,6 +72,7 @@ def add_anet_cmdline_args(parser):
     parser.add_argument(
         "--anet-indices",
         nargs=2,
+        env_var="AUTOWISP_ANET_INDICES",
         default=(
             (
                 rf"C:\Users\{getpass.getuser()}"

--- a/autowisp/tests/__main__.py
+++ b/autowisp/tests/__main__.py
@@ -285,6 +285,15 @@ def main():
     try:
         with data_dir_cm as test_dir:
             get_test_data(test_dir, local_source=args.test_data)
+            # Point solve_astrometry at the astrometry.net indices bundled in
+            # the test data (env overrides the config path). Environments with
+            # no local solve-field (e.g. Windows without ANSVR) fall back to the
+            # web solver via astrometry.local_solver_available().
+            anet_indices = path.join(test_dir, "anet_indices")
+            if path.isdir(anet_indices):
+                os.environ["AUTOWISP_ANET_INDICES"] = (
+                    f"[{anet_indices}, {anet_indices}]"
+                )
             processing_dir = path.join(test_dir, "processing")
             print(f"Test data directory: {test_dir!r}")
             print(f"Test data contents: {glob(test_dir + '/*')}")

--- a/autowisp/tests/get_test_data.py
+++ b/autowisp/tests/get_test_data.py
@@ -19,7 +19,7 @@ def download_zip(destination):
         print("Re-using existing 'test_data.zip'")
         return result
     req = requests.get(
-        "https://zenodo.org/records/21494020/files/test_data.zip",
+        "https://zenodo.org/records/21501301/files/test_data.zip",
         timeout=60,
     )
     if not req.ok:


### PR DESCRIPTION
# Robust astrometry in CI

## Problem

`TestSolveAstrometry` needs an initial blind plate solve, chosen in
`autowisp/astrometry/astrometry.py::get_initial_corr`: if both `anet_indices` dirs
exist → local `solve-field`, else the astrometry.net **web** API. On CI the
configured `anet_indices` were the developer's local macOS paths (absent on the
runners), so every cell fell back to the web solver; the full grid fired ~100
concurrent web solves, astrometry.net's public queue backed up, and each cell
exceeded the 3600 s `run_step` timeout.

## Design (implemented, validated locally)

Solve locally where a solver is available; fall back to web where it isn't;
ship the indices with the test data so there is no third-party dependency.

- **Indices in the test-data bundle** — `anet_indices/index-4108..4112.fits`
  (official astrometry.net 4100-series; solvers are 4108/4109/4111, 4110/4112 are
  cheap margin, 4107 excluded as huge and unused; ~185 MB). Single controlled
  source (Zenodo), versioned with the fixtures, immune to astrometry.net outages,
  and the dev no longer needs a local index install.
- **Harness points at them in place** — `tests/__main__.py`: after
  `get_test_data`, if `<test_dir>/anet_indices` exists, set
  `AUTOWISP_ANET_INDICES="[<dir>, <dir>]"`. No copying into per-test processing
  dirs. Uses the `env_var="AUTOWISP_ANET_INDICES"` on `--anet-indices` (env
  overrides the config file value).
- **Web fallback is automatic** — `get_initial_corr` now also requires
  `local_solver_available()`: a machine with indices but no solver degrades to
  web instead of failing. It is OS-aware and preserves the Windows/ANSVR path
  (`_ansvr_bash()`: on Windows, checks for the cygwin ANSVR bash the local solver
  is invoked through; else, `shutil.which("solve-field")`). So:
  - Linux/macOS (solve-field installed) → local, fast, offline;
  - Windows (no solve-field/ANSVR on the runner) → web — and as the only Windows
    cell it is the one live web-astrometry check, with no queue pileup.
- **Workflow** — install `solve-field` on Linux (`apt-get install astrometry.net`)
  and macOS (`brew install astrometry-net`); the step is skipped on Windows and
  uses an explicit `case` so `brew` can only run on macOS. No download/cache step
  (indices come from the bundle).
- **API key** — the existing `kqrzybsrrzomydyc` in the bundle's `test.cfg` is
  valid and kept (used only by the Windows web cell).

## Validation

- Local (macOS): `TestSolveAstrometry` passes using the public 4108–4112 indices
  via the env override, and via the harness auto-detecting a bundled
  `anet_indices/` (`add_path` confirms the bundle dir is used). The final,
  catalog-refined solution reproduces the fixture, so it is index/seed
  independent.
- Remaining, CI-only: Linux `solve-field` (apt) reproducing the fixture; macOS
  `brew` install; the Windows web cell finishing without the old pileup.

## Completed steps

1. **Code/workflow** (this branch): `astrometry.py` (`local_solver_available` +
   `_ansvr_bash`, gate in `get_initial_corr`), `solve_astrometry.py`
   (`env_var` on `--anet-indices`), `tests/__main__.py` (set env from bundle),
   `run_tests.yml` (install solve-field on Linux/macOS).
2. **Bundle** (user): add `anet_indices/index-4108..4112.fits` to the test-data
   bundle, re-upload to a new Zenodo record, bump the URL in `get_test_data.py`.
3. **Validate on CI**: dispatch the grid; expect Linux/macOS to solve locally and
   fast, the single Windows cell to solve via web without pileup, no timeouts.
