### PR TITLE
Floor the outlier-rejection residual scale for EPD/TFA

### DIFF
--- a/autowisp/fit_expression/iterative_fit.py
+++ b/autowisp/fit_expression/iterative_fit.py
@@ -8,7 +8,7 @@ import scipy.linalg
 
 
 # pylint: disable=too-many-locals
-def iterative_fit_qr(
+def iterative_fit_qr( # pylint: disable=too-many-arguments
     weighted_predictors,
     weighted_qrp,
     weighted_target,
@@ -20,6 +20,7 @@ def iterative_fit_qr(
     max_rej_iter,
     fit_identifier,
     pre_reject=False,
+    reject_scale_floor=0.0,
 ):
     """
     Same as iterative_fit() but using the QR decomposition of predictors.
@@ -74,7 +75,10 @@ def iterative_fit_qr(
                 res2 /= numpy.mean(pow(weights, 2))
         else:
             res2 = getattr(numpy, error_avg)(fit_diff2)
-        max_diff2 = rej_level**2 * res2
+        # Floor the residual scale so a (near-)perfect fit (res2 ~ 0) does not
+        # collapse the rejection threshold to ~0 and reject points on
+        # floating-point noise (a platform-dependent way to fail the fit).
+        max_diff2 = rej_level**2 * max(res2, reject_scale_floor**2)
         logger.debug("max square difference: %s", repr(max_diff2))
         if res2 < 0:
             logger.debug(
@@ -197,7 +201,7 @@ def iterative_fit_qr(
 # pylint: enable=too-many-locals
 
 
-def iterative_fit(
+def iterative_fit(# pylint: disable=too-many-arguments
     predictors,
     target_values,
     *,
@@ -208,6 +212,7 @@ def iterative_fit(
     max_rej_iter,
     fit_identifier,
     pre_reject=False,
+    reject_scale_floor=0.0,
 ):
     """
     Find least squares coefficients reproducing target_values using predictors.
@@ -284,4 +289,5 @@ def iterative_fit(
         max_rej_iter=max_rej_iter,
         fit_identifier=fit_identifier,
         pre_reject=pre_reject,
+        reject_scale_floor=reject_scale_floor,
     )

--- a/autowisp/processing_steps/epd.py
+++ b/autowisp/processing_steps/epd.py
@@ -43,6 +43,7 @@ def epd(lc_collection, start_status, configuration, mark_progress):
             error_avg=configuration["detrend_error_avg"],
             rej_level=configuration["detrend_rej_level"],
             max_rej_iter=configuration["detrend_max_rej_iter"],
+            reject_scale_floor=configuration["detrend_reject_scale_floor"],
             pre_reject=configuration["pre_reject_outliers"],
             mark_progress=mark_progress,
         ),

--- a/autowisp/processing_steps/lc_detrending_argument_parser.py
+++ b/autowisp/processing_steps/lc_detrending_argument_parser.py
@@ -541,6 +541,17 @@ class LCDetrendingArgumentParser(ManualStepArgumentParser):
             "perform. If the fit has not converged by then, the latest "
             "iteration is accepted. Default: %(default)s",
         )
+        self.add_argument(
+            "--detrend-reject-scale-floor",
+            type=float,
+            default=1e-5,
+            help="Floor on the residual scale (in the units of the fitted "
+            "quantity) used for outlier rejection. Without it, a (near-)perfect "
+            "fit has a residual ~0, collapsing the rejection threshold to ~0 so "
+            "that points get rejected on floating-point noise -- which can, "
+            "platform-dependently, reject enough points to fail the fit. "
+            "Default: %(default)s",
+        )
         if add_reconstructive:
             self.add_argument(
                 "--target-id",

--- a/autowisp/processing_steps/tfa.py
+++ b/autowisp/processing_steps/tfa.py
@@ -64,6 +64,7 @@ def tfa(lc_collection, start_status, configuration, mark_progress):
             error_avg=configuration["detrend_error_avg"],
             rej_level=configuration["detrend_rej_level"],
             max_rej_iter=configuration["detrend_max_rej_iter"],
+            reject_scale_floor=configuration["detrend_reject_scale_floor"],
             fit_identifier="TFA",
             verify_template_data=True,
             mark_progress=mark_progress,


### PR DESCRIPTION
A (near-)perfect detrending fit has residual ~0, which collapses the outlier- rejection threshold (rej_level**2 * res2) to ~0. Points then get rejected on floating-point noise, and enough can be rejected to drop below the number of fit coefficients -- returning no solution and leaving the "unfit" sentinel. Whether that happens is platform/LAPACK dependent, which surfaced as a TestTFA failure on only the macOS-arm + numpy-1 CI cell (one source's Aperture003 fit, whose light curve lies essentially exactly in the template span, residual ~1e-16).

Add a --detrend-reject-scale-floor option (default 1e-5, in the units of the fitted quantity) flooring the residual scale used for rejection: max_diff2 = rej_level**2 * max(res2, floor**2). It only engages for degenerate fits (res2 < floor**2), so well-conditioned fits -- and magfit/PSF/star-shape, which don't pass it -- are unchanged, and the degenerate case becomes deterministic across platforms.