### PR TITLE
TFA: variable template counts (vlen) + selection diagnostics + tests

### DIFF
--- a/autowisp/light_curves/light_curve_file.py
+++ b/autowisp/light_curves/light_curve_file.py
@@ -32,6 +32,20 @@ class LightCurveFile(HDF5FileDatabaseStructure):
             configuration indices (re-used if requested again).
     """
 
+    #: Config datasets whose per-configuration value is itself an array of
+    #: varying length, so they must be stored as ragged (variable-length)
+    #: datasets rather than a fixed-width 2-D array. Currently the TFA template
+    #: star IDs, whose count differs between configurations (e.g. per color
+    #: channel). The element type stays whatever the database declares; only the
+    #: ragged (vlen) storage is imposed here, so no structure/database change is
+    #: needed and existing databases work unchanged.
+    _ragged_config_keys = frozenset(
+        {
+            "shapefit.tfa.cfg.template_source_ids",
+            "apphot.tfa.cfg.template_source_ids",
+        }
+    )
+
     @classmethod
     def _product(cls):
         return "light_curve"
@@ -41,6 +55,19 @@ class LightCurveFile(HDF5FileDatabaseStructure):
         """The name of the root tag in the layout configuration."""
 
         return "LightCurve"
+
+    def get_dtype(self, element_key):
+        """Store the ragged config datasets as variable-length arrays.
+
+        See :attr:`_ragged_config_keys`: these hold one array per configuration
+        whose length varies, so a fixed-width dataset cannot represent them. The
+        element type is the database-declared one, wrapped as vlen; all other
+        keys defer to the database dtype unchanged.
+        """
+
+        if element_key in self._ragged_config_keys:
+            return h5py.vlen_dtype(super().get_dtype(element_key))
+        return super().get_dtype(element_key)
 
     def _get_hashable_dataset(self, dataset_key, **substitutions):
         """Return the selected dataset with hashable entries."""
@@ -382,12 +409,24 @@ class LightCurveFile(HDF5FileDatabaseStructure):
                             else value
                         )
             for key in config_data_to_add:
-                config_data_to_add[key] = numpy.array(
-                    config_data_to_add[key],
-                    dtype=h5py.check_dtype(
-                        vlen=numpy.dtype(self.get_dtype(key))
-                    ),
+                vlen_base = h5py.check_dtype(
+                    vlen=numpy.dtype(self.get_dtype(key))
                 )
+                if vlen_base is not None and vlen_base not in (bytes, str):
+                    # Ragged numeric config: each configuration's value is an
+                    # array of possibly differing length. Store as a 1-D object
+                    # array of arrays so h5py writes them as variable-length
+                    # rows (a fixed-width array would fail to broadcast).
+                    ragged = numpy.empty(
+                        len(config_data_to_add[key]), dtype=object
+                    )
+                    for index, value in enumerate(config_data_to_add[key]):
+                        ragged[index] = numpy.asarray(value, dtype=vlen_base)
+                    config_data_to_add[key] = ragged
+                else:
+                    config_data_to_add[key] = numpy.array(
+                        config_data_to_add[key], dtype=vlen_base
+                    )
             config_data_to_add[component + ".cfg_index"] = index_dset
             return config_data_to_add
 
@@ -541,7 +580,15 @@ class LightCurveFile(HDF5FileDatabaseStructure):
                     dataset[confirmed_length - pad : confirmed_length] = (
                         get_pad_value(dataset_config.replace_nonfinite)
                     )
-                dataset[confirmed_length:] = data_copy
+                if data_copy.dtype == object:
+                    # Variable-length (ragged) rows: h5py mishandles
+                    # slice-assignment of a 1-D object array whose element is a
+                    # uniform-length array (it reads it as a fixed 2-D source and
+                    # fails to broadcast). Assign each ragged row by scalar index.
+                    for offset in range(len(data_copy)):
+                        dataset[confirmed_length + offset] = data_copy[offset]
+                else:
+                    dataset[confirmed_length:] = data_copy
 
         dataset_config = self._file_structure[dataset_key]
         dataset_path = dataset_config.abspath % substitutions

--- a/autowisp/light_curves/tfa_correction.py
+++ b/autowisp/light_curves/tfa_correction.py
@@ -357,87 +357,141 @@ class TFACorrection(Correction):
                     1
                 ]
             )
-            print("Template indices: " + repr(template_indices))
+            self._logger.debug("Template indices: %s", repr(template_indices))
             return numpy.nonzero(allowed_stars)[0][template_indices]
 
         # TODO: simplify the logic below (too many things appear redundant)
         self._logger.debug("Selecting templates from: %s", repr(epd_statistics))
+        num_stars = len(epd_statistics["mag"])
         saturated = (
             epd_statistics["mag"] < self._configuration["saturation_magnitude"]
         )
-        self._logger.debug(
-            "There are %s unsaturated stars.",
-            numpy.logical_not(saturated).sum(),
+        bright_enough = (
+            epd_statistics["mag"] < self._configuration["faint_mag_limit"]
         )
-        min_observations = min(
-            numpy.quantile(
-                epd_statistics["num_finite"],
-                self._configuration["min_observations_quantile"],
-            ),
-            (
-                self._configuration["min_observations_fraction"]
-                * epd_statistics["num_finite"].max()
-            ),
+
+        obs_quantile = numpy.quantile(
+            epd_statistics["num_finite"],
+            self._configuration["min_observations_quantile"],
         )
-        self._logger.debug(
-            "Requiring at least %s observations", repr(min_observations)
+        obs_fraction = (
+            self._configuration["min_observations_fraction"]
+            * epd_statistics["num_finite"].max()
         )
+        min_observations = min(obs_quantile, obs_fraction)
+        enough_observations = epd_statistics["num_finite"] >= min_observations
 
         bright_and_long_lc = numpy.logical_and(
-            (epd_statistics["mag"] < self._configuration["faint_mag_limit"])[
-                :, None
-            ],
-            epd_statistics["num_finite"] >= min_observations,
+            bright_enough[:, None], enough_observations
         )
 
-        self._logger.debug(
-            "There are %s non-faint stars with sufficient observations",
-            bright_and_long_lc.sum(0),
-        )
-
-        acceptable_rms = select_typical_rms_stars(
+        # Stars whose RMS is typical for their magnitude (not intrinsic
+        # variables); a separate cut from ``max_rms`` below.
+        typical_rms = select_typical_rms_stars(
             numpy.logical_and(
                 numpy.logical_not(saturated[:, None]), bright_and_long_lc
             )
         )
 
         if self._configuration["allow_saturated_templates"]:
-            acceptable_rms = numpy.logical_or(
-                saturated[:, None], acceptable_rms
-            )
+            acceptable_rms = numpy.logical_or(saturated[:, None], typical_rms)
         else:
             acceptable_rms = numpy.logical_and(
-                numpy.logical_not(saturated)[:, None], acceptable_rms
+                numpy.logical_not(saturated)[:, None], typical_rms
             )
-        acceptable_rms = numpy.logical_and(
-            epd_statistics["rms"] < self._configuration["max_rms"],
-            acceptable_rms,
-        )
-
-        self._logger.debug(
-            "Requiring at least %d observations", min_observations
-        )
-        self._logger.debug(
-            "There are %s stars with low RMS", acceptable_rms.sum(0)
-        )
+        low_rms = epd_statistics["rms"] < self._configuration["max_rms"]
+        acceptable_rms = numpy.logical_and(low_rms, acceptable_rms)
 
         allowed_stars = numpy.logical_and(bright_and_long_lc, acceptable_rms)
 
         allowed_star_count = allowed_stars.sum(0)
-        allowed_stars[:, allowed_star_count == 0] = bright_and_long_lc[
-            :, allowed_star_count == 0
-        ]
+        used_fallback = allowed_star_count == 0
+        allowed_stars[:, used_fallback] = bright_and_long_lc[:, used_fallback]
 
-        self._logger.debug("There are %s overlap stars", allowed_stars.sum(0))
+        # Stages 1-4 of the selection funnel (per-star cuts, shared by all
+        # channels) -- see the per-channel stages logged in the loop below.
+        self._logger.debug(
+            "Template selection funnel: %d stars total; %d unsaturated "
+            "(mag >= %s); %d bright enough (mag < %s); min_observations = %s "
+            "(min of quantile[%s] = %s and %s * max = %s).",
+            num_stars,
+            int(numpy.logical_not(saturated).sum()),
+            self._configuration["saturation_magnitude"],
+            int(bright_enough.sum()),
+            self._configuration["faint_mag_limit"],
+            repr(min_observations),
+            self._configuration["min_observations_quantile"],
+            repr(obs_quantile),
+            self._configuration["min_observations_fraction"],
+            repr(obs_fraction),
+        )
 
         num_photometries = epd_statistics["rms"][0].size
+        grid_size = self._configuration["sqrt_num_templates"] ** 2
 
         result = []
-
         for photometry_index in range(num_photometries):
-            result.append(
-                select_template_stars(allowed_stars[:, photometry_index])
+            selected = select_template_stars(
+                allowed_stars[:, photometry_index]
             )
+            result.append(selected)
+
+            # Stages 5-7 (remaining per-channel cuts) at debug.
+            self._logger.debug(
+                "Channel %d funnel: %d with enough observations; %d bright & "
+                "long-LC; %d typical RMS for mag; %d also RMS < %s.",
+                photometry_index,
+                int(enough_observations[:, photometry_index].sum()),
+                int(bright_and_long_lc[:, photometry_index].sum()),
+                int(typical_rms[:, photometry_index].sum()),
+                int(acceptable_rms[:, photometry_index].sum()),
+                self._configuration["max_rms"],
+            )
+            # Stages 8-9 (candidates + grid collapse) at info.
+            candidates = int(allowed_stars[:, photometry_index].sum())
+            self._logger.info(
+                "Channel %d: %d candidate template stars%s -> %d selected "
+                "(grid of %d points).",
+                photometry_index,
+                candidates,
+                (
+                    " [fallback: no star passed every cut, using the "
+                    "bright & long-LC set]"
+                    if used_fallback[photometry_index]
+                    else ""
+                ),
+                len(selected),
+                grid_size,
+            )
+            if len(selected) < grid_size:
+                self._logger.warning(
+                    "TFA selected only %d of the expected %d templates for "
+                    "channel %d. Funnel: %d stars total -> %d unsaturated -> "
+                    "%d bright (mag < %s) -> %d with >= %s observations -> "
+                    "%d typical RMS for mag -> %d also RMS < %s -> %d allowed"
+                    "%s -> %d after collapsing %d grid points to distinct "
+                    "nearest stars.",
+                    len(selected),
+                    grid_size,
+                    photometry_index,
+                    num_stars,
+                    int(numpy.logical_not(saturated).sum()),
+                    int(bright_enough.sum()),
+                    self._configuration["faint_mag_limit"],
+                    int(enough_observations[:, photometry_index].sum()),
+                    repr(min_observations),
+                    int(typical_rms[:, photometry_index].sum()),
+                    int(acceptable_rms[:, photometry_index].sum()),
+                    self._configuration["max_rms"],
+                    candidates,
+                    (
+                        " (fallback to bright & long-LC)"
+                        if used_fallback[photometry_index]
+                        else ""
+                    ),
+                    len(selected),
+                    grid_size,
+                )
 
         if getattr(self._configuration, "selected_plots", None) is not None:
             self._plot_template_selection(

--- a/autowisp/tests/__main__.py
+++ b/autowisp/tests/__main__.py
@@ -32,6 +32,10 @@ from autowisp.tests.test_fit_magnitudes import TestFitMagnitudes
 from autowisp.tests.test_create_lightcurves import TestCreateLightcurves
 from autowisp.tests.test_epd import TestEPD
 from autowisp.tests.test_tfa import TestTFA
+from autowisp.tests.test_tfa_num_templates import (
+    TestTemplateSourceIdsVlen,
+    TestTemplateSelectionDiagnostics,
+)
 from autowisp.tests.test_detrending_stat import TestDetrendingStat
 from autowisp.tests.test_catalog import TestCatalog
 from autowisp.tests.test_lc_filter import (

--- a/autowisp/tests/get_test_data.py
+++ b/autowisp/tests/get_test_data.py
@@ -10,16 +10,19 @@ import requests
 
 
 def download_zip(destination):
-    """Download the test data zip file from Zenodo."""
+    """Download the test data zip file from Zenodo.
 
-    print("Starting download")
+    To reuse a local bundle instead (to skip re-fetching the large archive, or
+    to test against a regenerated bundle), pass it explicitly with the
+    ``--test-data`` command-line argument -- a file in the current directory is
+    deliberately *not* picked up implicitly, as that silently overrode Zenodo
+    and produced confusing passes against a stale bundle.
+    """
+
+    print("Downloading test data from Zenodo ...")
     result = path.join(destination, "test_data.zip")
-    if path.exists("test_data.zip"):
-        shutil.copyfile("test_data.zip", result)
-        print("Re-using existing 'test_data.zip'")
-        return result
     req = requests.get(
-        "https://zenodo.org/records/21501301/files/test_data.zip",
+        "https://zenodo.org/records/21539385/files/test_data.zip",
         timeout=60,
     )
     if not req.ok:
@@ -68,9 +71,8 @@ def get_test_data(destination, local_source=None):
             "nor a directory."
         )
 
-    print(f"Downloading test data to {destination!r} ...")
     with ZipFile(download_zip(destination), "r") as zip_ref:
-        print(f"Unzipping all files to {destination!r} ...")
+        print(f"Unzipping test data to {destination!r} ...")
         zip_ref.extractall(destination)
 
 

--- a/autowisp/tests/h5_test_case.py
+++ b/autowisp/tests/h5_test_case.py
@@ -121,6 +121,23 @@ class H5TestCase(AutoWISPTestCase):
                         + f"\n\t{data2[differ]}"
                         + f"\n\tdiff: {data1[differ] - data2[differ]}\n\t"
                     )
+            elif dset1.dtype.kind == "O":
+                # Variable-length (ragged) rows -- each entry is itself an
+                # array (e.g. TFA TemplateStarIDs). Compare row by row.
+                mismatched = [
+                    index
+                    for index in range(len(data1))
+                    if not numpy.array_equal(data1[index], data2[index])
+                ]
+                if mismatched:
+                    self.fail(
+                        f"Data in datasets {dr_fname1!r}/{dset1.name!r} and "
+                        f"{dr_fname2!r}/{dset2.name!r} do not match "
+                        f"(different rows: {mismatched})."
+                        f"\n{dr_fname1!r}/{dset1.name!r}"
+                        f"\n\t{[data1[index] for index in mismatched]}"
+                        f"\n\t{[data2[index] for index in mismatched]}"
+                    )
             else:
                 differ = data1 != data2
                 if numpy.any(differ):

--- a/autowisp/tests/meson.build
+++ b/autowisp/tests/meson.build
@@ -30,6 +30,7 @@ py_src = [
   'test_solve_astrometry.py',
   'test_stack_to_master.py',
   'test_tfa.py',
+  'test_tfa_num_templates.py',
 ]
 
 py.install_sources(

--- a/autowisp/tests/test_tfa_num_templates.py
+++ b/autowisp/tests/test_tfa_num_templates.py
@@ -1,0 +1,228 @@
+"""Unit tests for variable TFA template counts and selection diagnostics.
+
+These are deliberately self-contained (no downloaded test-data bundle): the
+bundle cannot exercise a *varying* template count because every test channel
+happens to select the same number, so the ragged-storage regression and the
+short-count warning are covered here instead.
+"""
+
+import logging
+import unittest
+from shutil import rmtree
+from tempfile import mkdtemp
+
+import h5py
+import numpy
+
+from autowisp.database.interface import set_project_home
+from autowisp.light_curves.hashable_array import HashableArray
+from autowisp.light_curves.light_curve_file import LightCurveFile
+from autowisp.light_curves.tfa_correction import TFACorrection
+
+#: The two config datasets whose per-config value is a variable-length array of
+#: template star IDs.
+_TEMPLATE_KEYS = (
+    "shapefit.tfa.cfg.template_source_ids",
+    "apphot.tfa.cfg.template_source_ids",
+)
+
+
+class TestTemplateSourceIdsVlen(unittest.TestCase):
+    """Ragged storage of the TFA ``TemplateStarIDs`` config datasets."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Point the DB/project home at a throwaway directory."""
+
+        cls._project_home = mkdtemp(prefix="autowisp_vlen_")
+        set_project_home(cls._project_home)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Drop the throwaway project home."""
+
+        rmtree(cls._project_home, ignore_errors=True)
+
+    def test_dtype_override_is_vlen(self):
+        """``get_dtype`` reports a vlen dtype (of the DB base) for the keys."""
+
+        with LightCurveFile() as light_curve:
+            for key in _TEMPLATE_KEYS:
+                dtype = light_curve.get_dtype(key)
+                self.assertEqual(
+                    dtype.kind,
+                    "O",
+                    f"{key} should be stored as a variable-length dtype",
+                )
+                # The element type stays whatever the database declared
+                # (uint64), only wrapped as vlen.
+                self.assertEqual(
+                    numpy.dtype(h5py.check_dtype(vlen=dtype)),
+                    numpy.dtype(numpy.uint64),
+                )
+
+    def test_varying_template_counts_round_trip(self):
+        """Appending configs of *different* template counts must not broadcast.
+
+        Reproduces the production crash (``Can't broadcast (1, 12) ->
+        (1, 10)``): one TFA run stores a width-10 row, a later run for the same
+        source appends a width-12 row. With fixed-2D storage the append failed;
+        as ragged rows it succeeds and round-trips.
+        """
+
+        key = "shapefit.tfa.cfg.template_source_ids"
+        num_frames = 3
+        template_id_sets = (
+            numpy.arange(10, dtype=numpy.uint64),
+            numpy.arange(100, 112, dtype=numpy.uint64),  # length 12
+            numpy.arange(200, 208, dtype=numpy.uint64),  # length 8
+        )
+
+        with LightCurveFile() as light_curve:
+            # Give the LC a defined length so the config-append path (rather
+            # than fresh creation) is exercised -- that is where the broadcast
+            # crash lived.
+            light_curve.add_dataset(
+                "skypos.BJD",
+                numpy.arange(num_frames, dtype=float),
+                unlimited=True,
+            )
+            light_curve.confirm_lc_length()
+
+            for template_ids in template_id_sets:
+                light_curve.add_configurations(
+                    component="shapefit.tfa",
+                    configurations=(
+                        ((key, HashableArray(template_ids)),),
+                    ),
+                    config_indices=numpy.zeros(num_frames, dtype=numpy.uint),
+                )
+
+            dataset = light_curve[light_curve.get_element_path(key)]
+            self.assertEqual(dataset.dtype.kind, "O")
+            self.assertEqual(dataset.shape, (len(template_id_sets),))
+            for index, expected in enumerate(template_id_sets):
+                numpy.testing.assert_array_equal(dataset[index], expected)
+
+
+class _TemplateSelectionHarness(TFACorrection):
+    """A ``TFACorrection`` exposing just the template-selection step.
+
+    The full ``TFACorrection.__init__`` reads per-light-curve template
+    measurements and observation IDs (``_prepare_template_data``), which needs
+    real data. ``_select_template_stars`` only consults the configuration and
+    the (passed-in) EPD statistics, so this harness sets the configuration and
+    skips the data-reading construction.
+    """
+
+    # pylint: disable=super-init-not-called
+    def __init__(self, configuration):
+        self._configuration = configuration
+
+
+class TestTemplateSelectionDiagnostics(unittest.TestCase):
+    """The short-count warning emitted by ``_select_template_stars``."""
+
+    _logger_name = "autowisp.light_curves.tfa_correction"
+
+    @staticmethod
+    def _make_epd_statistics(num_stars):
+        """A single-photometry structured array that survives every cut.
+
+        All stars are unsaturated, bright, long-LC, and follow a clean
+        magnitude-RMS relation (small scatter so the typical-RMS fit keeps
+        them), spread over a 2-D field.
+        """
+
+        dtype = numpy.dtype(
+            [
+                ("mag", "f8"),
+                ("num_finite", "i8", (1,)),
+                ("rms", "f8", (1,)),
+                ("xi", "f8"),
+                ("eta", "f8"),
+            ]
+        )
+        epd_statistics = numpy.zeros(num_stars, dtype=dtype)
+        magnitude = numpy.linspace(10.0, 11.0, num_stars)
+        epd_statistics["mag"] = magnitude
+        epd_statistics["num_finite"][:, 0] = 100
+        scatter = numpy.random.default_rng(0).normal(0.0, 0.02, num_stars)
+        epd_statistics["rms"][:, 0] = 10.0 ** (
+            -2.0 - 0.1 * (magnitude - 10.0) + scatter
+        )
+        positions = numpy.linspace(0.0, 1.0, num_stars)
+        epd_statistics["xi"] = positions
+        epd_statistics["eta"] = positions[::-1]
+        return epd_statistics
+
+    @staticmethod
+    def _configuration(sqrt_num_templates):
+        """Config with cuts loose enough that every synthetic star passes."""
+
+        return {
+            "saturation_magnitude": 8.0,
+            "faint_mag_limit": 12.0,
+            "min_observations_quantile": 0.5,
+            "min_observations_fraction": 0.5,
+            "mag_rms_dependence_order": 1,
+            "mag_rms_outlier_threshold": 5.0,
+            "mag_rms_max_rej_iter": 3,
+            "max_rms": 0.05,
+            "allow_saturated_templates": False,
+            "sqrt_num_templates": sqrt_num_templates,
+        }
+
+    def test_shortfall_emits_warning(self):
+        """Fewer selected than ``sqrt_num_templates**2`` logs a warning.
+
+        Ten eligible stars against a 4x4 (=16) grid: the grid-nearest-neighbor
+        collapse yields fewer than 16 distinct templates, which must warn and
+        report the per-stage funnel.
+        """
+
+        num_stars = 10
+        sqrt_num_templates = 4
+        grid_size = sqrt_num_templates**2
+        selector = _TemplateSelectionHarness(
+            self._configuration(sqrt_num_templates)
+        )
+
+        with self.assertLogs(self._logger_name, logging.WARNING) as captured:
+            selected = selector._select_template_stars(  # pylint: disable=protected-access
+                self._make_epd_statistics(num_stars)
+            )
+
+        self.assertEqual(len(selected), 1)
+        self.assertLess(len(selected[0]), grid_size)
+
+        warnings = [
+            record.getMessage()
+            for record in captured.records
+            if record.levelno == logging.WARNING
+        ]
+        self.assertEqual(len(warnings), 1)
+        message = warnings[0]
+        self.assertIn(f"of the expected {grid_size}", message)
+        self.assertIn("channel 0", message)
+        # The funnel counts are reported so the shortfall is explainable.
+        self.assertIn(f"{num_stars} stars total", message)
+
+    def test_full_count_no_warning(self):
+        """Enough distinct templates for the grid must not warn."""
+
+        # A 1x1 grid needs a single template; ten eligible stars easily clear
+        # it, so no shortfall warning should fire.
+        selector = _TemplateSelectionHarness(
+            self._configuration(sqrt_num_templates=1)
+        )
+
+        with self.assertNoLogs(self._logger_name, logging.WARNING):
+            selected = selector._select_template_stars(  # pylint: disable=protected-access
+                self._make_epd_statistics(10)
+            )
+        self.assertEqual(len(selected[0]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,9 @@ dependencies = [
     'astrowisp >= 2.0.1',
     'configargparse',
     'Django',
-    'h5py',
+    # >= 2.10 for the new dtype API (vlen_dtype/string_dtype/check_enum_dtype,
+    # all added in 2.10.0); modern installs are 3.x regardless.
+    'h5py >= 2.10',
     'lxml',
     'matplotlib',
     # meepmeep is transitive-only (via pytransit); we never import it. Pin <1


### PR DESCRIPTION
Store the TFA template star IDs (shapefit/apphot .cfg.template_source_ids) as ragged variable-length datasets so one light curve can hold TFA configs with differing template counts (per color channel / photref), fixing the production crash "TFAError: Can't broadcast (1, 12) -> (1, 10)".

- light_curve_file.py: override get_dtype for the two template keys to vlen(<db dtype>); build and append them as ragged object arrays in add_configurations (no DB/structure change, works on existing DBs).
- tfa_correction._select_template_stars: log the per-channel selection funnel (stages 1-7 debug, 8-9 info) and warn when fewer than sqrt_num_templates**2 templates are selected; drop stray prints.
- h5_test_case: compare ragged (object) datasets row by row.
- get_test_data: point at the regenerated (vlen) Zenodo bundle; drop the implicit cwd test_data.zip reuse in favour of the explicit --test-data arg (the implicit reuse silently overrode Zenodo and masked this change).
- pyproject: pin h5py >= 2.10 (vlen/string/enum dtype API).
- tests: add self-contained test_tfa_num_templates (ragged round-trip that reproduces the crash + shortfall-warning), wired into the runner and meson.